### PR TITLE
Apoli需要用20a6d55545版本(2.9.2)，gradle.properties中需要修改

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx8G
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
 	fabric_version=0.92.3+1.20.1
-	apoli_version = 2.9.0
+apoli_version=20a6d55545
 	reach_version = 2.4.0
 	breathing_lib_version = 01269c3
 	mod_menu_version = 7.2.2


### PR DESCRIPTION
不改成这个版本游戏就是进不去，就是很奇怪
测试环境：
- 使用 `connector` 分支 Dev Version #13构建的 JAR 包；
- 启动时崩溃，日志见附件：[latest.log](https://github.com/user-attachments/files/24364186/latest.log)

我认为应该是Apoli2.9.0版本没有给信雅互联做兼容的缘故
Apoli `2.9.2`（对应 commit `20a6d55545`）已修复对信雅互联的兼容
将依赖更新至 `2.9.2` 后，游戏正常启动且功能正常
此 PR 仅修改 `gradle.properties` 中的 Apoli 版本号，无其他改动